### PR TITLE
Render empty view instead of null when no popups

### DIFF
--- a/lib/PopupStub.js
+++ b/lib/PopupStub.js
@@ -220,7 +220,9 @@ export default class PopupStub extends Component {
 
   render () {
     if (this.state.popups.size === 0) {
-      return null
+      // It's weird to not use null here,
+      // but it can make sure that the stub will be refreshed eventually.
+      return <View style={{position: 'absolute', left: 0, top: 0, height: 0, width: 0}} />
     }
 
     return (


### PR DESCRIPTION
In some odd devices, it happens that it when a popup is removed and a new one is added, it won't refresh.
Thanks to @eric.